### PR TITLE
fix(expense card): add conditional so if date is not given it defaults to today's date

### DIFF
--- a/Components/ExpenseModal.tsx
+++ b/Components/ExpenseModal.tsx
@@ -54,7 +54,7 @@ const ExpenseModal = () => {
         label: label,
         saved: amount,
         goal: amount,
-        date: Number(date),
+        date: date > 0 ? Number(date) : Date.now(),
       })
     );
   };


### PR DESCRIPTION
**Changes**
Add conditional to line 57 in `ExpenseModal.tsx` so that if date is not greater than zero, then defaults to today's date.

**Purpose**
So that if the user doesn't select a date, then today's date is added to the expense by default.

**Approach**
Added conditional statement to make sure that, if a date wasn't selected, then today's date is added to the expense by default.

Closes #58