### PR TITLE
fix(AccountsModal) : add a function that will prevent non-numerical c…

### DIFF
--- a/Components/AccountModal.tsx
+++ b/Components/AccountModal.tsx
@@ -59,6 +59,20 @@ const AccountModal = memo<Props>(({ account, unselectedAccounts, isVisible, setI
       dispatch(editAccount([...unselectedAccounts, accountUpdate]));
       setIsVisible(false);
     }
+    // This function will prevent non-numerical charachters from entered into the amount input 
+    const onChanged = (text:any) => {
+      let newText:any="";
+      let numbers = '0123456789';
+      for (var i=0; i < text.length; i++) {
+          if(numbers.indexOf(text[i]) > -1 ) {
+              newText = newText + text[i];
+          }
+          else {
+              alert("please enter numbers only");
+          }
+      }
+      setAmount(newText);
+  }
 
   return (
      <Modal
@@ -80,7 +94,7 @@ const AccountModal = memo<Props>(({ account, unselectedAccounts, isVisible, setI
           <TextInput 
             style={styles.amountInput} 
             placeholder="amount"
-            onChangeText={text => setAmount(Number(text))}
+            onChangeText={text =>onChanged(text)}
             value={amount?.toString()}
           />
           {/* This will include the text input for the label */}

--- a/Components/AccountModal.tsx
+++ b/Components/AccountModal.tsx
@@ -58,7 +58,7 @@ const AccountModal = memo<Props>(
     const onChanged = (text:any) => {
       let newText:any="";
       let numbers = '0123456789.';
-      for (var i=0; i < text.length; i++) {
+      for (let i=0; i < text.length; i++) {
           if(numbers.indexOf(text[i]) > -1 ) {
               newText = newText + text[i];
           }

--- a/Components/AccountModal.tsx
+++ b/Components/AccountModal.tsx
@@ -57,7 +57,7 @@ const AccountModal = memo<Props>(
 
     const onChanged = (text:any) => {
       let newText:any="";
-      let numbers = '0123456789';
+      let numbers = '0123456789.';
       for (var i=0; i < text.length; i++) {
           if(numbers.indexOf(text[i]) > -1 ) {
               newText = newText + text[i];


### PR DESCRIPTION
## Changes
1. add a function to restrict amount input filed to only accept numbers  
2. add an alert functionality if user enters wrong characters

## Purpose
The edit modal   allows non-numerical values to be entered. This causes the input field to display NAN errors whenever the user enters a letter. 

## Approach
Inputs other than numerical values are no longer permitted. Users will be alerted that they can only input numerical values. 

## Learning
Used Typescript and stack overflow to find a solution
https://www.mywebtuts.com/blog/react-native-textinput-number-only

Closes #65