### PR TITLE
Ga 70 calcuate correct balance

### DIFF
--- a/Components/AccountModal.tsx
+++ b/Components/AccountModal.tsx
@@ -13,7 +13,7 @@ import { addAccount, editAccount } from "../Utils/accountSlice";
 import { recalculateBudget } from "../Utils/remainingBudgetSlice";
 import { GlobalStateType, AccountType } from "../Utils/types";
 import { Feather } from '@expo/vector-icons';
-import { expenseSlice } from "../Utils/expenseSlice";
+
 
 const { width, height } = Dimensions.get("screen");
 

--- a/Components/AccountModal.tsx
+++ b/Components/AccountModal.tsx
@@ -10,8 +10,10 @@ import {
 import React, {memo, useState, useEffect} from "react";
 import { useSelector, useDispatch } from "react-redux";
 import { addAccount, editAccount } from "../Utils/accountSlice";
+import { recalculateBudget } from "../Utils/remainingBudgetSlice";
 import { GlobalStateType, AccountType } from "../Utils/types";
 import { Feather } from '@expo/vector-icons';
+import { expenseSlice } from "../Utils/expenseSlice";
 
 const { width, height } = Dimensions.get("screen");
 
@@ -31,6 +33,7 @@ const AccountModal = memo<Props>(({ account, unselectedAccounts, isVisible, setI
     const [label, setLabel] = useState<string>("");
     const dispatch = useDispatch();
     const accounts = useSelector((state: GlobalStateType) => state.accounts.list);
+    const expenses = useSelector((state: GlobalStateType) => state.expenses.list);
 
     useEffect(
       () => {
@@ -47,6 +50,10 @@ const AccountModal = memo<Props>(({ account, unselectedAccounts, isVisible, setI
         date: Date.now(),
       };
       dispatch(addAccount(newAccount));
+      dispatch(recalculateBudget({
+        expenses: expenses,
+        accounts:[...accounts, newAccount],
+      }))
     }
 
     const runEditAccount = () => {
@@ -58,6 +65,10 @@ const AccountModal = memo<Props>(({ account, unselectedAccounts, isVisible, setI
       };
       dispatch(editAccount([...unselectedAccounts, accountUpdate]));
       setIsVisible(false);
+      dispatch(recalculateBudget({
+        expenses: expenses,
+        accounts:[...unselectedAccounts, accountUpdate],
+      }))
     }
 
   return (


### PR DESCRIPTION
## Changes
1. Import recalculateBudget action into `ExpenseModal.tsx`
2. Use useSelector to extract the states for remainingBudget and accounts into consts
3. In `runAddAccount` and `runEditAccount` functions, add dispatch to recalculate budget.  Accepts expenses and accounts.


## Purpose
When you add a new account or edit an existing account, the balance amount will display the updated amount.

## Approach
This will show the correct amount balance.

## Learning
After pulling the latest from the develop branch, the `AccountModal` component wasn't rendering when testing, but there were no errors in the code.  This Stack Overflow helped me trace where my problem was.
[](https://github.com/facebook/react/issues/18178#issuecomment-595846312)

Closes #70