### PR TITLE
fix(AccountModal):add conditional for amount value and adjust height …

### DIFF
--- a/Components/AccountModal.tsx
+++ b/Components/AccountModal.tsx
@@ -103,7 +103,7 @@ const AccountModal = memo<Props>(
               style={styles.amountInput}
               placeholder="amount"
               onChangeText={text =>onChanged(text)}
-              value={amount?.toString()}
+              value={mode !== "add" ? amount?.toString() : undefined}
             />
             {/* This will include the text input for the label */}
             <TextInput
@@ -151,9 +151,10 @@ const styles = StyleSheet.create({
     textAlign: "center",
   },
   addButton: {
-    width: 130,
-    height: 34,
+    width: 140,
+    height: 44,
     borderRadius: 10,
+    alignItems: "center",
     alignSelf: "center",
     flexDirection: "row",
     backgroundColor: "white",


### PR DESCRIPTION
**Changes**
* Added conditional in the value for the amount TextInput, so that if the mode is "add" then it will show the placeholder text. 
* Adjusted the height of the "addButton" style
* Adjusted the width of the "addButton" style
* Added `alignItems: "center"` to center the text vertically for the "Add Account" button

**Purpose**
* Make the placeholder text show for "amount" when you open the add account modal
* Make the "Add Account" button big enough to hold it's text on both web and mobile

**Approach**
* Added conditional to check which mode the modal is in, so that if it is in "add" mode the "amount" placeholder text will show.
* Adjust the styling(height, width, and alignItems) for the "addButton" styles so that the label text for the button appears correctly on both web and mobile.

**Learning**
No real new learning for this, as it was just a normal ternary conditional and adjusting css.

Closes #80