### PR TITLE
fix(Overview): change the postion of profile icon from left to rigth …

### DIFF
--- a/Screens/Overview.tsx
+++ b/Screens/Overview.tsx
@@ -43,8 +43,8 @@ const styles = StyleSheet.create({
     alignSelf: "center"
   },
   icon:{
-    alignSelf:"flex-start",
-    marginLeft:"2%",
+    alignSelf:"flex-end",
+    marginRight:"2%",
     marginTop:"2%",
   },
   plusModal: {


### PR DESCRIPTION

## Changes
1. Move the profile icon from the top left to the top right of the screen


## Purpose
The profile icon should be moved from the screen's top left to the top right to match the design wireframe.

## Approach
Change the style of the icon on the Overview page.



Close #86