### PR TITLE
Ajm 59 horizontal scroll bug

### DIFF
--- a/Components/ExpenseCard.tsx
+++ b/Components/ExpenseCard.tsx
@@ -20,8 +20,8 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderRadius: 23,
     aspectRatio: 1,
-    margin: 15,
-    height: 155,
+    margin: 8,
+    height: 180,
   },
   expenseAmount: {
     textAlign: "center",

--- a/Components/ExpenseCard.tsx
+++ b/Components/ExpenseCard.tsx
@@ -21,7 +21,7 @@ const styles = StyleSheet.create({
     borderRadius: 23,
     aspectRatio: 1,
     margin: 15,
-    height: 160,
+    height: 155,
   },
   expenseAmount: {
     textAlign: "center",

--- a/Components/ExpenseCard.tsx
+++ b/Components/ExpenseCard.tsx
@@ -21,7 +21,7 @@ const styles = StyleSheet.create({
     borderRadius: 23,
     aspectRatio: 1,
     margin: 8,
-    height: 180,
+    height: 160,
   },
   expenseAmount: {
     textAlign: "center",

--- a/Screens/Overview.tsx
+++ b/Screens/Overview.tsx
@@ -13,7 +13,7 @@ function Overview() {
       <View style={styles.icon}>
 				<ProfileIcon/>
 			</View>
-      <ScrollView>
+      <ScrollView style={styles.scrollViewContainer}>
         <View style={styles.budgetCardHolder}>      
           <BudgetCard />
         </View>
@@ -34,13 +34,16 @@ const styles = StyleSheet.create({
     alignItems: "center",
     width: "100%",
   },
+  scrollViewContainer: {
+    width: "100%",
+  },
   budgetCardHolder: {
     marginTop: 30,
     width: "100%",
   },
   expenseCardHolder: {
     marginTop: 20,
-    alignSelf: "center"
+    alignSelf: "center",
   },
   icon:{
     alignSelf:"flex-start",


### PR DESCRIPTION
**Changes**
1. `Overview.tsx` Add width to ScrollView container style
2. `ExpenseCard.tsx` Change width on container style

**Purpose**
* Remove overflow horizontal scrolling on iOS and web in mobile viewports.

**Approach**
* Add 100% width to ScrollView container style
* Change ExpenseCard container width to 160. Margin from 15 to 8
  * ExpenseList might look off center as a side effect. Will need to fix that in a future bug ticket.

**Learning**
None

Close #59 