### PR TITLE
feat(expense): redesign css and add bar with text

### DIFF
--- a/Components/ExpenseCard.tsx
+++ b/Components/ExpenseCard.tsx
@@ -1,13 +1,34 @@
 import React from "react";
 import { StyleSheet, Text, View } from "react-native";
+// cannot deep require import according to
+// https://github.com/oblador/react-native-progress#progressbar
+import * as Progress from "react-native-progress";
+import { LinearGradient } from "expo-linear-gradient";
 
 export default function ExpenseCard(expense: any, index: number) {
   return (
     <>
       <View style={styles.container}>
-        <Text style={styles.expenseAmount}>${expense.expense.saved}</Text>
-        <Text style={styles.expenseLabel}>{expense.expense.label}</Text>
-        <Text style={styles.expenseDate}>{new Date(expense.expense.date).toLocaleDateString()}</Text>
+        <LinearGradient
+          colors={["#2383C9", "#102745"]}
+          style={styles.linearGradient}
+        >
+          <Text style={styles.expenseLabel}>{expense.expense.label}</Text>
+          <Text style={styles.expenseDate}>{new Date(expense.expense.date).toLocaleDateString()}</Text>
+          <Text style={styles.expenseAmount}>${expense.expense.saved}</Text>
+          <View style={styles.bar}>
+            <Progress.Bar
+                  progress={expense.expense.saved / expense.expense.goal || 0}
+                  unfilledColor="#DBDBDB"
+                  borderColor="rgba(0,0,0,0)"
+                  borderRadius={5}
+                  width={142}
+                  height={6}
+                  color="#05C473"
+                />
+          </View>
+          <Text style={styles.expenseProgress}>${expense.expense.saved} of ${expense.expense.goal} saved</Text>
+        </LinearGradient>
       </View>
     </>
   );
@@ -17,36 +38,65 @@ const styles = StyleSheet.create({
   container: {
     alignItems: "center",
     justifyContent: "center",
-    borderWidth: 1,
     borderRadius: 23,
     aspectRatio: 1,
-    margin: 8,
-    height: 160,
+    margin: 15,
+    height: 180,
   },
   expenseAmount: {
     textAlign: "center",
     fontSize: 30,
     lineHeight: 34,
     fontFamily: "Sarabun_700Bold",
+    color: "white",
     position: "absolute",
-    top: 52,
+    paddingVertical: 73,
+    paddingHorizontal: 55,
   },
   expenseLabel: {
-    fontSize: 18,
+    fontSize: 20,
     lineHeight: 23,
     fontFamily: "Sarabun_600SemiBold",
+    color: "white",
     alignSelf: "flex-start",
-    marginLeft: 22,
+    marginLeft: 19,
     position: "absolute",
-    bottom: 37,
+    top: 16,
   },
   expenseDate: {
+    fontSize: 17,
+    lineHeight: 20,
+    fontFamily: "Sarabun_300Light",
+    color: "white",
+    alignSelf: "flex-start",
+    marginLeft: 19,
+    position: "absolute",
+    top: 40,
+  },
+  expenseProgress: {
     fontSize: 14,
     lineHeight: 20,
     fontFamily: "Sarabun_300Light",
+    color: "white",
     alignSelf: "flex-start",
-    marginLeft: 22,
+    marginLeft: 19,
     position: "absolute",
-    bottom: 17,
+    bottom: 16,
+  },
+  linearGradient: {
+    alignItems: "center",
+		justifyContent: "center",
+		borderRadius: 23,
+    height: 180,
+    aspectRatio: 1,
+		alignSelf: "center",
+  },
+  bar: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 19,
+    position: "absolute",
+    bottom: 36,
   },
 });


### PR DESCRIPTION
**Changes**

- Redesign CSS to match Figma
- Add react native progress bar
- Add saved/goal text under bar
- Add expo linear gradient

**Purpose**

- Match Figma design

**Approach**

- Edit CSS
- Add react native progress bar
- Add saved/goal text under bar
- Add expo linear gradient

Close #81