### PR TITLE
gh 97 Progress Bar Value Bug

### DIFF
--- a/Components/BudgetCard.tsx
+++ b/Components/BudgetCard.tsx
@@ -28,7 +28,7 @@ export default function BudgetCard() {
           </Text>
           <View style={styles.bar}>
             <Progress.Bar
-              progress={moneyRem / moneyTotal || .3}
+              progress={moneyRem / moneyTotal || 0}
               unfilledColor="#DBDBDB"
               borderColor="rgba(0,0,0,0)"
               borderRadius={8}


### PR DESCRIPTION
**Changes**

- BudgetCard.tsx : changed the default value in the progress bar

**Purpose**

The purpose of this bug ticket was to change the default state value of the progress bar. Before I made changes the progress bar would show it was 30% full before there was any number value to account for. So my main job for this ticket was to make it show 0% full at its default state as it would reciprocate nothing being accounted for.

**Approach**

My Approach to this ticket was to look inside the budgetcard.tsx file, look through the logic, and see what is being passed into the progress bar that could be giving it a false value.


Close #97 