### PR TITLE
feat(expense uuid): add uuid to expense redux state #112

### DIFF
--- a/Components/ExpenseModal.tsx
+++ b/Components/ExpenseModal.tsx
@@ -9,6 +9,7 @@ import {
   Platform,
   Modal,
 } from "react-native";
+import uuid from "react-native-uuid";
 import { DatePickerModal } from "react-native-paper-dates"; //date picker for web
 import { AntDesign, Feather } from "@expo/vector-icons";
 import { useSelector, useDispatch } from "react-redux";
@@ -73,7 +74,8 @@ const ExpenseModal = () => {
 				saved: amount,
 				goal: amount,
 				date: date > 0 ? Number(date) : Date.now(),
-			};
+        id: uuid.v4().toString(),
+      };
 			dispatch(addExpense(newExpense));
 			dispatch(
 				recalculateBudget({

--- a/Components/ReduxStateTest.tsx
+++ b/Components/ReduxStateTest.tsx
@@ -55,6 +55,7 @@ const ReduxStateTest: FC = () => {
       saved: 80,
       goal: 80,
       date: Date.now(),
+      id: uuid.v4().toString(),
     };
     dispatch(addExpense(newExpense));
 

--- a/Utils/types.ts
+++ b/Utils/types.ts
@@ -32,6 +32,7 @@ export interface ExpenseType {
   saved: number;
   goal: number;
   date: number;
+  id: string;
 }
 
 export interface RemainingBudgetType {


### PR DESCRIPTION
## Changes
1. Add `id` as UUID value to Expense object in Redux State

## Purpose
Simplify passing expenses between components by using the Expense ID from Redux State

## Approach
Adding the `id` value to the Expense object provides a clear way to get a given expense from Redux State by it's ID

## Learning
none - thank you @darlanebrown

Closes #112 