### PR TITLE
chore(fixed): fixed the word wrap and center the tiles

### DIFF
--- a/Components/ExpenseCard.tsx
+++ b/Components/ExpenseCard.tsx
@@ -1,9 +1,11 @@
 import React from "react";
-import { StyleSheet, Text, View } from "react-native";
+import { StyleSheet, Text, View, Dimensions } from "react-native";
 // cannot deep require import according to
 // https://github.com/oblador/react-native-progress#progressbar
 import * as Progress from "react-native-progress";
 import { LinearGradient } from "expo-linear-gradient";
+
+const { width } = Dimensions.get("window");
 
 export default function ExpenseCard(expense: any, index: number) {
   return (
@@ -22,7 +24,7 @@ export default function ExpenseCard(expense: any, index: number) {
                   unfilledColor="#DBDBDB"
                   borderColor="rgba(0,0,0,0)"
                   borderRadius={5}
-                  width={142}
+                  width={100}
                   height={6}
                   color="#05C473"
                 />
@@ -41,7 +43,7 @@ const styles = StyleSheet.create({
     borderRadius: 23,
     aspectRatio: 1,
     margin: 15,
-    height: 180,
+    width: width/2.5> 180? 180:width/2.5,
   },
   expenseAmount: {
     textAlign: "center",
@@ -51,7 +53,6 @@ const styles = StyleSheet.create({
     color: "white",
     position: "absolute",
     paddingVertical: 73,
-    paddingHorizontal: 55,
   },
   expenseLabel: {
     fontSize: 20,
@@ -87,7 +88,7 @@ const styles = StyleSheet.create({
     alignItems: "center",
 		justifyContent: "center",
 		borderRadius: 23,
-    height: 180,
+    width:"100%",
     aspectRatio: 1,
 		alignSelf: "center",
   },

--- a/Components/ExpenseList.tsx
+++ b/Components/ExpenseList.tsx
@@ -28,7 +28,7 @@ const ExpenseList = () => {
 					<ExpenseDetailView SetShowModal={SetShowModal} />
 			) : (
 			
-			<View style={{ flexDirection: "row", flexWrap: "wrap" }}>
+			<View style={{ flexDirection: "row", flexWrap: "wrap", justifyContent: "center" }}>
 				{generateExpenses}
 			</View>
 			)}

--- a/Components/ExpenseModal.tsx
+++ b/Components/ExpenseModal.tsx
@@ -200,11 +200,11 @@ const styles = StyleSheet.create({
     paddingBottom: 30,
   },
   titleText: {
-    fontSize: 25,
+    fontSize: 35,
   },
   inputStyle: {
-    width: 150,
-    height: 30,
+     width: 150,
+     height: 30,
     borderWidth: 1,
     borderColor: "#000",
     fontSize: 20,

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "react-native-progress": "^5.0.0",
     "react-native-safe-area-context": "4.2.4",
     "react-native-screens": "~3.11.1",
+    "react-native-super-grid": "^4.4.0",
     "react-native-uuid": "^2.0.1",
     "react-native-web": "0.17.7",
     "react-redux": "^8.0.2",


### PR DESCRIPTION
Changes
List Changes Introduced by this PR

Item 1 deleted the padding horizontal 55 in Expense Card
Item 2 delete height in container on Expense Card and replace it(  width: width/2.5> 180? 180:width/2.5,) and added import Dimensions

Approach
How does this change address the problem?
item 1 now the numbers on the tile Expense card are in align
item 2 the tiles line up side by side and center
Learning
Describe the research stage
Besides the headache- I did install React native Super Grid but didn't work well on the web, use Flexbox

Links to blog posts, patterns, libraries, or add-ons used to solve this problem

Closes #102