### PR TITLE
feat(subject placeholder): Add default placeholder to subject state #121

### DIFF
--- a/Screens/ContactForm.tsx
+++ b/Screens/ContactForm.tsx
@@ -17,7 +17,7 @@ type Props = NativeStackScreenProps<RootStackParamList, "ContactForm">
 
 const ContactForm:FC<Props> = ({ navigation }) => {
   const [email, setEmail] = useState<string>("");
-  const [subject, setSubject] = useState<string>("");
+  const [subject, setSubject] = useState<string>("placeholder 1");
   const [message, setMessage] = useState<string>("");
  
   
@@ -70,7 +70,7 @@ const ContactForm:FC<Props> = ({ navigation }) => {
           />
         <Picker.Item 
           label="placeholder 2" 
-          value="jplaceholder 2"
+          value="placeholder 2"
           />
         </Picker>
 


### PR DESCRIPTION
## Changes
1. Updated subject useState default from empty string to "placeholder 1"
2. Fixed typo in value for Picker.Item placeholder 2


## Purpose
This was done so if the user doesn't pick a subject, the subject line will default to "placeholder 1"

## Approach
This is a better user experience for the person receiving the email

## Learning
N/A

Closes #121 