### PR TITLE
Sr 123 bugfix edit expense

### DIFF
--- a/Components/ExpenseModal.tsx
+++ b/Components/ExpenseModal.tsx
@@ -40,6 +40,7 @@ const ExpenseModal = ({
   const [confirm, setConfirm] = useState<boolean>(false);
   const expenses = useSelector((state: GlobalStateType) => state.expenses.list);
   const appData = useSelector((state: GlobalStateType) => state.app);
+  
   const dispatch = useDispatch();
 
   useEffect(()=> {

--- a/Components/ExpenseModal.tsx
+++ b/Components/ExpenseModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import {
   View,
   Text,
@@ -40,8 +40,11 @@ const ExpenseModal = ({
   const [confirm, setConfirm] = useState<boolean>(false);
   const expenses = useSelector((state: GlobalStateType) => state.expenses.list);
   const appData = useSelector((state: GlobalStateType) => state.app);
-
   const dispatch = useDispatch();
+
+  useEffect(()=> {
+    appData?.modalMode === "add" && setLabel("");
+  }, [appData.expenseModalVisibility])
 
   const showDatePicker = () => {
     setDatePickerVisibility(true);
@@ -245,9 +248,6 @@ const ExpenseModal = ({
               <TouchableOpacity
                 onPress={() => {
                   runEditExpense();
-                  setLabel("");
-                  setAmount(0);
-                  setDate(0);
                   dispatch(setExpenseModalVisibility(false));
                 }}
                 style={styles.buttonStyle}
@@ -267,7 +267,6 @@ const ExpenseModal = ({
               </TouchableOpacity>
             </View>
           )}
-
           {/* This is where the form ends */}
         </View>
       </Modal>

--- a/Components/ExpenseModal.tsx
+++ b/Components/ExpenseModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback } from "react";
 import {
   View,
   Text,
@@ -42,10 +42,6 @@ const ExpenseModal = ({
   const appData = useSelector((state: GlobalStateType) => state.app);
 
   const dispatch = useDispatch();
-
-  useEffect(() => {
-    appData?.modalMode === "add" && setLabel("");
-  }, [appData.modalMode]);
 
   const showDatePicker = () => {
     setDatePickerVisibility(true);
@@ -185,7 +181,7 @@ const ExpenseModal = ({
             </Text>
             <TextInput
               style={styles.inputStyle}
-              value={label}
+              value={appData?.modalMode === "add" ? undefined : label}
               onChangeText={(text) => {
                 setLabel(text);
               }}
@@ -235,8 +231,6 @@ const ExpenseModal = ({
             <TouchableOpacity
               onPress={() => {
                 runAddExpense();
-                setLabel("");
-                setAmount(0);
                 setDate(0);
                 dispatch(setExpenseModalVisibility(false));
               }}

--- a/Components/ExpenseModal.tsx
+++ b/Components/ExpenseModal.tsx
@@ -40,12 +40,12 @@ const ExpenseModal = ({
   const [confirm, setConfirm] = useState<boolean>(false);
   const expenses = useSelector((state: GlobalStateType) => state.expenses.list);
   const appData = useSelector((state: GlobalStateType) => state.app);
-  
+
   const dispatch = useDispatch();
 
-  useEffect(()=> {
+  useEffect(() => {
     appData?.modalMode === "add" && setLabel("");
-  }, [appData.expenseModalVisibility])
+  }, [appData.modalMode]);
 
   const showDatePicker = () => {
     setDatePickerVisibility(true);


### PR DESCRIPTION
**Changes**
1. Imported useEffect.
2. Added a useEffect to reset the label in the ExpenseModal whenever the expenseModalVisibility state changes and the mode is set to "add".
3. Removed the lines that reset the label whenever the ExpenseModal was edited.
4. Removed the useEffect, decided to try to find a less complex solution, and found a bug with this solution.
5. Added conditional in value property of the Label to account for the different modal modes.
6. Removed lines that reset the values of amount and label after an expense is added because the conditionals now cover the same functionality.

**Purpose**
This was done so that if a user wants to edit an expense a second time, after already editing it once, the information for the expense still shows up in the form.

**Approach**
Initially, every time a user edited an expense the label was reset.  Now, the label is not reset if the user wants to re-edit the same expense. This was accomplished by removing the code that automatically reset the label when an expense is edited, but this necessitated adding a way to reset the label whenever a new expense is added, so I also added the useEffect.  However, I found a bug with this solution and found it overly complex, so I removed the useEffect and added a conditional to the value property of the `<TextInput>` for the label instead.

**Learning**
Focused on trying to use a solution that didn't add unnecessary complexity to the app and that required the least amount of change to the code base while hopefully accomplishing the necessary fix.

Closes #123