### PR TITLE
feat(add expense): convert to component and position absolute #125

### DIFF
--- a/Components/Expenses/AddExpense.tsx
+++ b/Components/Expenses/AddExpense.tsx
@@ -1,0 +1,30 @@
+import { StyleSheet, TouchableOpacity } from "react-native";
+import { setModalMode, setExpenseModalVisibility } from "../../Utils/appSlice";
+import { useDispatch } from "react-redux";
+import { AntDesign } from "@expo/vector-icons";
+
+const AddExpense = () => {
+  const dispatch = useDispatch();
+
+  return (
+    <TouchableOpacity
+      style={styles.plusModal}
+      onPress={() => {
+        dispatch(setExpenseModalVisibility(true));
+        dispatch(setModalMode("add"));
+      }}
+    >
+      <AntDesign name="pluscircle" size={48} color="#4D62BF" />
+    </TouchableOpacity>
+  );
+};
+
+export default AddExpense;
+
+const styles = StyleSheet.create({
+  plusModal: {
+    position: "absolute",
+    bottom: 15,
+    right: 15,
+  },
+});

--- a/Screens/Overview.tsx
+++ b/Screens/Overview.tsx
@@ -1,12 +1,10 @@
-import { View, StyleSheet, ScrollView, TouchableOpacity } from "react-native";
+import { View, StyleSheet, ScrollView } from "react-native";
 import { FC, useState } from "react";
 import ExpenseList from "../Components/ExpenseList";
 import BudgetCard from "../Components/BudgetCard";
-import { useDispatch } from "react-redux";
 import { ExpenseType } from "../Utils/types";
-import { setModalMode, setExpenseModalVisibility } from "../Utils/appSlice";
 import ExpenseModal from "../Components/ExpenseModal";
-import { AntDesign } from "@expo/vector-icons";
+import AddExpense from "../Components/Expenses/AddExpense";
 import uuid from "react-native-uuid";
 
 import type { NativeStackScreenProps } from "@react-navigation/native-stack";
@@ -22,7 +20,6 @@ const Overview: FC<Props> = ({ navigation }) => {
     date: Date.now(),
     id: uuid.v4().toString(),
   };
-  const dispatch = useDispatch();
 
   const [label, setLabel] = useState<string>("");
   const [amount, setAmount] = useState<number>(0);
@@ -52,15 +49,7 @@ const Overview: FC<Props> = ({ navigation }) => {
           expense={expense}
         />
       </View>
-      <TouchableOpacity
-        style={styles.plusModal}
-        onPress={() => {
-          dispatch(setExpenseModalVisibility(true));
-          dispatch(setModalMode("add"));
-        }}
-      >
-        <AntDesign name="pluscircle" size={48} color="#4D62BF" />
-      </TouchableOpacity>
+      <AddExpense />
     </View>
   );
 };
@@ -83,10 +72,6 @@ const styles = StyleSheet.create({
   expenseCardHolder: {
     marginTop: 20,
     alignSelf: "center",
-  },
-  plusModal: {
-    alignSelf: "flex-end",
-    padding: 30,
   },
 });
 


### PR DESCRIPTION
## Changes
1. Convert add expense button to component
2. absolutely position add expense component

## Purpose
Absolutely position the add expense button so that it is no longer in it's own flex container that restricts the space available to the expense list.

## Approach
Absolutely positioned the add expense button in order to take it out of the flex box flow and in that way, allow the expense container to flow to the bottom of the view-port. 

## Learning
none

https://stackoverflow.com/questions/29447715/react-native-fixed-footer

Closes #125