### PR TITLE
Jl 127 expense detail width

### DIFF
--- a/Components/ExpenseCard.tsx
+++ b/Components/ExpenseCard.tsx
@@ -14,18 +14,20 @@ export default function ExpenseCard(expense: any, index: number) {
           style={styles.linearGradient}
         >
           <Text style={styles.expenseLabel}>{expense.expense.label}</Text>
-          <Text style={styles.expenseDate}>{new Date(expense.expense.date).toLocaleDateString()}</Text>
+          <Text style={styles.expenseDate}>
+            {new Date(expense.expense.date).toLocaleDateString()}
+          </Text>
           <Text style={styles.expenseAmount}>${expense.expense.saved}</Text>
           <View style={styles.bar}>
             <Progress.Bar
-                  progress={expense.expense.saved / expense.expense.goal || 0}
-                  unfilledColor="#DBDBDB"
-                  borderColor="rgba(0,0,0,0)"
-                  borderRadius={5}
-                  width={100}
-                  height={6}
-                  color="#05C473"
-                />
+              progress={expense.expense.saved / expense.expense.goal || 0}
+              unfilledColor="#DBDBDB"
+              borderColor="rgba(0,0,0,0)"
+              borderRadius={5}
+              width={100}
+              height={6}
+              color="#05C473"
+            />
           </View>
           <Text style={styles.expenseProgress}>
             ${expense.expense.saved} of ${expense.expense.goal}
@@ -85,11 +87,11 @@ const styles = StyleSheet.create({
   },
   linearGradient: {
     alignItems: "center",
-		justifyContent: "center",
-		borderRadius: 23,
-    width:"100%",
+    justifyContent: "center",
+    borderRadius: 23,
+    width: "100%",
     aspectRatio: 1,
-		alignSelf: "center",
+    alignSelf: "center",
   },
   bar: {
     flexDirection: "row",

--- a/Components/ExpenseCard.tsx
+++ b/Components/ExpenseCard.tsx
@@ -1,11 +1,9 @@
 import React from "react";
-import { StyleSheet, Text, View, Dimensions } from "react-native";
+import { StyleSheet, Text, View } from "react-native";
 // cannot deep require import according to
 // https://github.com/oblador/react-native-progress#progressbar
 import * as Progress from "react-native-progress";
 import { LinearGradient } from "expo-linear-gradient";
-
-const { width } = Dimensions.get("window");
 
 export default function ExpenseCard(expense: any, index: number) {
   return (
@@ -29,7 +27,9 @@ export default function ExpenseCard(expense: any, index: number) {
                   color="#05C473"
                 />
           </View>
-          <Text style={styles.expenseProgress}>${expense.expense.saved} of ${expense.expense.goal} saved</Text>
+          <Text style={styles.expenseProgress}>
+            ${expense.expense.saved} of ${expense.expense.goal}
+          </Text>
         </LinearGradient>
       </View>
     </>
@@ -43,8 +43,7 @@ const styles = StyleSheet.create({
     borderRadius: 23,
     aspectRatio: 1,
     margin: 8,
-    height: width / 2.5 > 180 ? 180 : width / 2.5 < 160 ? 160 : width / 2.5,
-    width: width / 2.5 > 180 ? 180 : width / 2.5,
+    width: 160,
   },
   expenseAmount: {
     textAlign: "center",
@@ -80,7 +79,7 @@ const styles = StyleSheet.create({
     lineHeight: 20,
     fontFamily: "Sarabun_300Light",
     color: "white",
-    alignSelf: "flex-start",
+    alignSelf: "center",
     marginLeft: 19,
     position: "absolute",
     bottom: 16,

--- a/Components/ExpenseCard.tsx
+++ b/Components/ExpenseCard.tsx
@@ -80,7 +80,6 @@ const styles = StyleSheet.create({
     fontFamily: "Sarabun_300Light",
     color: "white",
     alignSelf: "center",
-    marginLeft: 19,
     position: "absolute",
     bottom: 16,
   },

--- a/Components/ExpenseDetailView.tsx
+++ b/Components/ExpenseDetailView.tsx
@@ -5,6 +5,7 @@ import {
   View,
   Platform,
   TouchableOpacity,
+  Dimensions,
 } from "react-native";
 import { useSelector, useDispatch } from "react-redux";
 import { GlobalStateType } from "../Utils/types";
@@ -24,6 +25,8 @@ import {
   setExpenseModalVisibility,
   setExpenseDetailsModalVisiblity,
 } from "../Utils/appSlice";
+
+const { width } = Dimensions.get("window");
 
 export default function ExpenseDetailView() {
   let [fontsLoaded] = useFonts({
@@ -59,8 +62,7 @@ export default function ExpenseDetailView() {
   Moment.locale("en");
   var dt = goalDate;
   return (
-    <View style={styles.container}>
-      <LinearGradient
+    <LinearGradient
         start={{ x: 0, y: 0 }}
         end={{ x: 1.6, y: 1 }}
         colors={["#2383C9", "#102745"]}
@@ -99,30 +101,24 @@ export default function ExpenseDetailView() {
                 color="#05C473"
                 unfilledColor="#DBDBDB"
                 borderColor="#DBDBDB"
-                width={235}
-                height={10}
+              width={width * 0.7 > 285 ? 285 : width * 0.7}
+              height={10}
               />
             </View>
           </View>
         </TouchableOpacity>
 
         <View style={styles.transactionsExpenses}>
-          <Text style={styles.RecentTransactions}> Recent Transactions </Text>
-        </View>
-      </LinearGradient>
-    </View>
+    </LinearGradient>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    alignItems: "center",
-    justifyContent: "center",
-    padding: 10,
-    height: 406,
-    width: 380,
+  linearGradient: {
+    flex: 1,
     borderRadius: 23,
     alignSelf: "center",
+    width: width - 30 > 380 ? 380 : width - 30,
     marginTop: Platform.OS === "web" ? "-35%" : "-30%",
   },
   linearGradient: {
@@ -160,10 +156,7 @@ const styles = StyleSheet.create({
     marginLeft: 22,
   },
   bar: {
-    flexDirection: "row",
-    height: 10,
     alignItems: "center",
-    justifyContent: "center",
   },
   exitIcon: {
     paddingRight: 10,
@@ -173,15 +166,14 @@ const styles = StyleSheet.create({
   modal: {
     backgroundColor: "#FFFFFF",
     borderRadius: 11,
-    width: 245,
-    height: 155,
     margin: 20,
     padding: 20,
   },
   transactionsExpenses: {
     backgroundColor: "#ffffff",
     borderRadius: 23,
-    width: "100%",
+    borderBottomLeftRadius: 0,
+    borderBottomRightRadius: 0,
   },
   RecentTransactions: {
     textAlign: "center",
@@ -191,7 +183,7 @@ const styles = StyleSheet.create({
     color: "#000000",
     backgroundColor: "#EEEEEE",
     borderRadius: 23,
-    width: 380,
-    height: 60,
+    borderBottomLeftRadius: 0,
+    borderBottomRightRadius: 0,
   },
 });

--- a/Components/ExpenseDetailView.tsx
+++ b/Components/ExpenseDetailView.tsx
@@ -11,15 +11,8 @@ import { useSelector, useDispatch } from "react-redux";
 import { GlobalStateType } from "../Utils/types";
 import { setSelectedId } from "../Utils/expenseSlice";
 import { LinearGradient } from "expo-linear-gradient";
-import {
-  useFonts,
-  Sarabun_700Bold,
-  Sarabun_400Regular,
-  Sarabun_300Light,
-} from "@expo-google-fonts/sarabun";
 import * as Progress from "react-native-progress";
 import { Feather } from "@expo/vector-icons";
-import Moment from "moment";
 import {
   setModalMode,
   setExpenseModalVisibility,
@@ -29,86 +22,62 @@ import {
 const { width } = Dimensions.get("window");
 
 export default function ExpenseDetailView() {
-  let [fontsLoaded] = useFonts({
-    Sarabun_700Bold,
-    Sarabun_400Regular,
-    Sarabun_300Light,
-  });
   const dispatch = useDispatch();
-  const selectedId = useSelector(
-    (state: GlobalStateType) => state.expenses.selectedId
-  );
-  const expenseLabel = useSelector(
-    (state: GlobalStateType) => state.expenses.list[selectedId].label
-  );
-  const goalDate = useSelector(
-    (state: GlobalStateType) => state.expenses.list[selectedId].date
-  );
-  const currentSaving = useSelector(
-    (state: GlobalStateType) => state.expenses.list[selectedId].saved
-  );
-  const targetAmount = useSelector(
-    (state: GlobalStateType) => state.expenses.list[selectedId].goal
-  );
-  const moneyTotal = useSelector(
-    (state: GlobalStateType) => state.budgets.remaining.accountsTotal
-  );
-  const milliseconds = goalDate;
-  const dateObject = new Date(milliseconds);
-  const forMatedDate = dateObject.toLocaleString("en-us", {
-    month: "short",
-    year: "numeric",
-  });
-  Moment.locale("en");
-  var dt = goalDate;
+
+  const expenses = useSelector((state: GlobalStateType) => state.expenses);
+
+  const expense = expenses.list[expenses.selectedId];
+
   return (
     <LinearGradient
-        start={{ x: 0, y: 0 }}
-        end={{ x: 1.6, y: 1 }}
-        colors={["#2383C9", "#102745"]}
-        style={styles.linearGradient}
+      start={{ x: 0, y: 0 }}
+      end={{ x: 1.6, y: 1 }}
+      colors={["#2383C9", "#102745"]}
+      style={styles.linearGradient}
+    >
+      <TouchableOpacity
+        onPress={() => {
+          dispatch(setExpenseModalVisibility(true));
+          dispatch(setModalMode("edit"));
+        }}
+        style={styles.expenseContainer}
       >
-        <TouchableOpacity
+        <Feather
+          style={styles.exitIcon}
+          name="x-circle"
+          size={24}
+          color="#FFFFFF"
           onPress={() => {
-            dispatch(setExpenseModalVisibility(true));
-            dispatch(setModalMode("edit"));
+            dispatch(setSelectedId(-1));
+            dispatch(setExpenseDetailsModalVisiblity(false));
           }}
-        >
-          <Feather
-            style={styles.exitIcon}
-            name="x-circle"
-            size={24}
-            color="#FFFFFF"
-            onPress={() => {
-              dispatch(setSelectedId(-1));
-              dispatch(setExpenseDetailsModalVisiblity(false));
-            }}
-          />
-          <Text style={styles.budgetTextTop}>{expenseLabel}</Text>
-          <Text style={styles.budgetText}>
-            {Platform.OS === "web"
-              ? forMatedDate
-              : Moment(dt).format("MMM YYYY")}
+        />
+        <Text style={styles.budgetTextTop}>{expense.label}</Text>
+        <Text style={styles.budgetText}>
+          {new Date(expense.date).toLocaleDateString()}
+        </Text>
+        <View style={styles.modal}>
+          <Text style={styles.savingText}>${expense.saved}</Text>
+          <Text style={styles.budgetTextBottom}>
+            ${expense.saved} of ${expense.goal}
           </Text>
-          <View style={styles.modal}>
-            <Text style={styles.savingText}>${currentSaving}</Text>
-            <Text style={styles.budgetTextBottom}>
-              ${currentSaving} of ${targetAmount}
-            </Text>
-            <View style={styles.bar}>
-              <Progress.Bar
-                progress={currentSaving / targetAmount || 0}
-                color="#05C473"
-                unfilledColor="#DBDBDB"
-                borderColor="#DBDBDB"
+          <View style={styles.bar}>
+            <Progress.Bar
+              progress={expense.saved / expense.goal || 0}
+              color="#05C473"
+              unfilledColor="#DBDBDB"
+              borderColor="#DBDBDB"
               width={width * 0.7 > 285 ? 285 : width * 0.7}
               height={10}
-              />
-            </View>
+            />
           </View>
-        </TouchableOpacity>
+        </View>
+      </TouchableOpacity>
 
-        <View style={styles.transactionsExpenses}>
+      <View style={styles.transactionsExpenses}>
+        <Text style={styles.RecentTransactions}>Recent Transactions</Text>
+        <Text style={{ textAlign: "center", padding: 10 }}>none</Text>
+      </View>
     </LinearGradient>
   );
 }
@@ -121,11 +90,8 @@ const styles = StyleSheet.create({
     width: width - 30 > 380 ? 380 : width - 30,
     marginTop: Platform.OS === "web" ? "-35%" : "-30%",
   },
-  linearGradient: {
-    alignItems: "center",
-    justifyContent: "center",
-    borderRadius: 23,
-    alignSelf: "center",
+  expenseContainer: {
+    padding: 10,
   },
   budgetText: {
     textAlign: "center",
@@ -148,9 +114,10 @@ const styles = StyleSheet.create({
   },
   budgetTextBottom: {
     textAlign: "center",
-    fontSize: 10,
+    fontSize: 14,
     fontFamily: "Sarabun_300Light",
     padding: 10,
+    paddingBottom: 0,
   },
   toggleArrow: {
     marginLeft: 22,
@@ -177,8 +144,8 @@ const styles = StyleSheet.create({
   },
   RecentTransactions: {
     textAlign: "center",
+    padding: 10,
     fontSize: 17,
-    fontWeight: "bold",
     fontFamily: "Sarabun_400Regular",
     color: "#000000",
     backgroundColor: "#EEEEEE",

--- a/Components/ExpenseDetailView.tsx
+++ b/Components/ExpenseDetailView.tsx
@@ -5,7 +5,7 @@ import {
   View,
   Platform,
   TouchableOpacity,
-  Dimensions,
+  useWindowDimensions,
 } from "react-native";
 import { useSelector, useDispatch } from "react-redux";
 import { GlobalStateType } from "../Utils/types";
@@ -19,9 +19,9 @@ import {
   setExpenseDetailsModalVisiblity,
 } from "../Utils/appSlice";
 
-const { width } = Dimensions.get("window");
-
 export default function ExpenseDetailView() {
+  const { width } = useWindowDimensions();
+
   const dispatch = useDispatch();
 
   const expenses = useSelector((state: GlobalStateType) => state.expenses);
@@ -33,7 +33,12 @@ export default function ExpenseDetailView() {
       start={{ x: 0, y: 0 }}
       end={{ x: 1.6, y: 1 }}
       colors={["#2383C9", "#102745"]}
-      style={styles.linearGradient}
+      style={[
+        styles.linearGradient,
+        {
+          width: width - 30 > 380 ? 380 : width - 30,
+        },
+      ]}
     >
       <TouchableOpacity
         onPress={() => {
@@ -87,7 +92,6 @@ const styles = StyleSheet.create({
     flex: 1,
     borderRadius: 23,
     alignSelf: "center",
-    width: width - 30 > 380 ? 380 : width - 30,
     marginTop: Platform.OS === "web" ? "-35%" : "-30%",
   },
   expenseContainer: {

--- a/Screens/Overview.tsx
+++ b/Screens/Overview.tsx
@@ -2,8 +2,8 @@ import { View, StyleSheet, ScrollView, TouchableOpacity } from "react-native";
 import { FC, useState } from "react";
 import ExpenseList from "../Components/ExpenseList";
 import BudgetCard from "../Components/BudgetCard";
-import { useDispatch } from "react-redux";
-import { ExpenseType } from "../Utils/types";
+import { useSelector, useDispatch } from "react-redux";
+import { ExpenseType, GlobalStateType } from "../Utils/types";
 import { setModalMode, setExpenseModalVisibility } from "../Utils/appSlice";
 import ExpenseModal from "../Components/ExpenseModal";
 import { AntDesign } from "@expo/vector-icons";
@@ -23,6 +23,8 @@ const Overview: FC<Props> = ({ navigation }) => {
     id: uuid.v4().toString(),
   };
   const dispatch = useDispatch();
+
+  const appData = useSelector((state: GlobalStateType) => state.app);
 
   const [label, setLabel] = useState<string>("");
   const [amount, setAmount] = useState<number>(0);
@@ -52,15 +54,17 @@ const Overview: FC<Props> = ({ navigation }) => {
           expense={expense}
         />
       </View>
-      <TouchableOpacity
-        style={styles.plusModal}
-        onPress={() => {
-          dispatch(setExpenseModalVisibility(true));
-          dispatch(setModalMode("add"));
-        }}
-      >
-        <AntDesign name="pluscircle" size={48} color="#4D62BF" />
-      </TouchableOpacity>
+      {!appData.expenseDetailsModalVisiblity && (
+        <TouchableOpacity
+          style={styles.plusModal}
+          onPress={() => {
+            dispatch(setExpenseModalVisibility(true));
+            dispatch(setModalMode("add"));
+          }}
+        >
+          <AntDesign name="pluscircle" size={48} color="#4D62BF" />
+        </TouchableOpacity>
+      )}
     </View>
   );
 };


### PR DESCRIPTION
## Changes
1. Adjust width of expense details container based on view-port width
2. Refactor expense details component and removed unneeded code

## Purpose
The expense modal was wider than the view-port so that it does not overflow the view-port window, and refactor the code to improve readability for future updates.

## Approach
The expense modal was wider than the view-port so that it does not overflow the view-port window, and refactor the code to improve readability for future updates.

## Learning
none

Closes #127